### PR TITLE
Add SUSE 15.3 image

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -270,3 +270,13 @@ oraclelinux:8.0
 EOS
 
 crane copy oraclelinux@sha256:157ec47eb5bfcb428432ca5365c6bf045189b68fbc62ffde7566dd66db1dca6d ${TEST_IMAGE}:oraclelinux8
+
+cat <<EOS
+
+##################################
+suse-15.3: suse/sle15:15.3.17.8.16
+##################################
+
+EOS
+
+crane copy registry.suse.com/suse/sle15@sha256:3c0b843c0d669e7851a65cea416644b7eefba03ea5b279ae8a2b82c29c61cc4b ${TEST_IMAGE}:suse-15.3


### PR DESCRIPTION
Add an image for SUSE 15.3: `registry.suse.com/suse/sle15:15.3.17.8.16`

a part of https://github.com/aquasecurity/trivy-test-images/pull/15