### PR TITLE
chore: bump ghcr.io/westonsteimel/containerd from 1.6.1 to 1.7.3

### DIFF
--- a/containerd/Dockerfile
+++ b/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/westonsteimel/containerd:1.6.1 as source
+FROM ghcr.io/westonsteimel/containerd:1.7.3 as source
 
 FROM alpine:3.15
 COPY --from=source /usr/local/bin/containerd /usr/local/bin/


### PR DESCRIPTION
## Description
Bump `ghcr.io/westonsteimel/containerd` from 1.6.1 to 1.7.3