### PR TITLE
feat(opensuse): add a opensuse tumbleweed reference image

### DIFF
--- a/copy-images.sh
+++ b/copy-images.sh
@@ -182,6 +182,17 @@ crane copy registry.opensuse.org/opensuse/leap@sha256:df3070b577cbdfd84dfb30d5ae
 
 cat <<EOS
 
+#############################################
+registry.opensuse.org/opensuse/tumbleweed:20240607.30.45
+#############################################
+
+EOS
+
+crane copy registry.opensuse.org/opensuse/tumbleweed@sha256:d5ca535ba690e75ccd8d88cb44e2dc783555955c6fe345ccfbf05d55cdf61ba8 ${TEST_IMAGE}:opensuse-tumbleweed
+
+
+cat <<EOS
+
 ###################
 photon:3.0-20190823
 ###################


### PR DESCRIPTION
added a tumbleweed testimage for use in trivy integration testing