### PR TITLE
ci: use `copy-images.sh` name in `Get changed files` step

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,7 +38,7 @@ jobs:
             spring4shell:
               - 'spring4shell/**'
             crane-images:
-              - push-crane-images.sh
+              - copy-images.sh
 
       - name: Push `busybox-with-lockfile` image
         if: steps.changed-files-yaml.outputs.busybox_any_changed == 'true'


### PR DESCRIPTION
## Description
Use `copy-images.sh` to trigger this script in `push` Action

test run - https://github.com/DmitriyLewen/trivy-test-images/actions/runs/9794352301/job/27044171661